### PR TITLE
Add encrypted databag support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,12 @@
 
 default['threatstack']['version'] = nil
 default['threatstack']['pkg_action'] = :install
-default['threatstack']['deploy_key'] = nil
 default['threatstack']['rulesets'] = ['Base Rule Set']
 default['threatstack']['hostname'] = nil
 default['threatstack']['ignore_failure'] = true
+
+# You can set the deploy key directly, or use the encrypted databag
+# parameters below. The value searched for will be 'deploy_key'
+default['threatstack']['deploy_key'] = nil
+default['threatstack']['data_bag_name'] = 'threatstack'
+default['threatstack']['data_bag_item'] = 'api_keys'

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -6,7 +6,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'debian',
         version: '7.8'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 
@@ -29,7 +31,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'ubuntu',
         version: '10.04'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 
@@ -48,7 +52,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'ubuntu',
         version: '12.04'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 
@@ -67,7 +73,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'ubuntu',
         version: '14.04'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 
@@ -86,7 +94,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'redhat',
         version: '6.5'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 
@@ -104,7 +114,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'centos',
         version: '6.5'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 
@@ -122,7 +134,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'amazon',
         version: '2012.09'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 


### PR DESCRIPTION
Explicitly specifying the deploy_key will take precedence.
Data bag name and item are configurable to account for environment
differences, as per best practice.
